### PR TITLE
Fix installation instruction for python docker package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Before starting you'll need to install
 
  - Docker
  - Ansible
-   - Also install the docker python module (e.g. `pip install docker`)
+   - Also install the docker python module (e.g. `pip install docker-py`)
  - Kind - Install guide [here](https://kind.sigs.k8s.io/docs/user/quick-start/)
 
 


### PR DESCRIPTION
On my playground system (Ubuntu 18.04) I got the following error message
when trying to start an environment:

```
TASK [Start up a docker container]
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to import
docker-py - No module named docker. Try `pip install docker-py`"}
```